### PR TITLE
Update version in README to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 -----
 
 ```
-addSbtPlugin("com.lightbend.sbt" % "sbt-multi-release-jar" % "0.1.0")
+addSbtPlugin("com.lightbend.sbt" % "sbt-multi-release-jar" % "0.1.2")
 ```
 
 This plugin allows you to keep "Java 9 only" sources in:


### PR DESCRIPTION
Looks like version 0.1.2 was released:
https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.lightbend.sbt/sbt-multi-release-jar/scala_2.12/sbt_1.0/0.1.2/jars/

Also @ktoso could you push the git tags, please?