### PR TITLE
Update sbt 1.2.8

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,1 +1,0 @@
--Djava.security.manager=default -Djava.security.policy=policy

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val commonSettings = Seq(
   organization := "com.lightbend.sbt",
 
-  crossSbtVersions := Vector("0.13.16", "1.0.2"),
+  crossSbtVersions := Vector("0.13.16", "1.2.8"),
 
   scalacOptions ++= List(
     "-unchecked",
@@ -30,6 +30,7 @@ name := "sbt-multi-release-jar"
 // publishing settings
 
 sbtPlugin := true
+enablePlugins(SbtPlugin)
 //publishTo := Some(Classpaths.sbtPluginReleases) // THIS IS BAD IN THE CURRENT PLUGIN VERSION
 publishMavenStyle := false
 

--- a/plugin-tester/project/build.properties
+++ b/plugin-tester/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.8

--- a/policy
+++ b/policy
@@ -1,3 +1,0 @@
-grant {
-    permission java.security.AllPermission;
-};

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
This PR updates to sbt 1.2.8 with the sbt 1.2.x bringing in a change that breaks the sbt build, specifically that `enablePlugins(SbtPlugin)` needs to be added. Without adding `enablePlugins(SbtPlugin)` you get

```
[error] Reference to undefined setting: 
[error] 
[error]   scriptedLaunchOpts from scriptedLaunchOpts (/Users/mdedetrich/github/sbt-multi-release-jar/build.sbt:25)
```

Another thing to note is that on my Macbook M1 I am getting the following error

```
Exception in thread "sbt-socket-server" java.lang.UnsatisfiedLinkError: Can't load library: /var/folders/x6/_f2z1gl567xc_03ds0v6q1p00000gn/T/jna-1186457089/jna17724004536604391803.tmp
```

But I believe the root cause is in https://github.com/sbt/sbt/issues/6215 in which case its erroneous because the version of sbt is so old that it doesn't support ARM (and if I do update the sbt version to something even newer, i.e. 1.9.7 the error goes away but I wan't to do this in a separate PR which will also add sbt-github-actions ). In any case `sbt scripted` still passes locally on my M1, its just the sbt server which is not working.