### PR TITLE
Update scalafmt native github action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,6 @@ jobs:
           persist-credentials: false
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v2
+        uses: jrouly/scalafmt-native-action@v3
         with:
-          version: '3.7.17'
           arguments: '--list --mode diff-ref=origin/main'


### PR DESCRIPTION
This PR has the advantage that it no longer needs its own hardcoded scalafmt version, instead it can read it from `.scalafmt.conf` which is the source of truth for the scalafmt version anyways.